### PR TITLE
feat: 블로그 댓글 기능 추가

### DIFF
--- a/src/app/api/posts/[id]/comments/[commentId]/route.ts
+++ b/src/app/api/posts/[id]/comments/[commentId]/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from "next/server"
+
+import {
+  CommentValidationError,
+  type CommentInput,
+} from "@/domains/blog/[uid]/comment-types"
+
+import {
+  CommentServiceError,
+  deleteComment,
+  updateComment,
+} from "../comment-service"
+
+export const dynamic = "force-dynamic"
+
+function jsonNoStore(body: unknown, status = 200) {
+  return NextResponse.json(body, {
+    status,
+    headers: {
+      "Cache-Control": "no-store",
+    },
+  })
+}
+
+function handleError(error: unknown) {
+  console.error("Comment Detail API Error:", error)
+
+  if (error instanceof CommentValidationError) {
+    return jsonNoStore({ error: error.message }, 400)
+  }
+
+  if (error instanceof CommentServiceError) {
+    return jsonNoStore({ error: error.message }, error.status)
+  }
+
+  const message =
+    error instanceof Error ? error.message : "Internal Server Error"
+
+  return jsonNoStore(
+    {
+      error: "Google Sheets API와 통신 중 오류가 발생했습니다.",
+      details: message,
+    },
+    500
+  )
+}
+
+async function parseCommentInput(request: NextRequest) {
+  try {
+    return (await request.json()) as CommentInput
+  } catch {
+    throw new CommentServiceError("잘못된 요청입니다.", 400)
+  }
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; commentId: string }> }
+) {
+  try {
+    const { id, commentId } = await params
+    const input = await parseCommentInput(request)
+
+    return jsonNoStore(await updateComment(id, commentId, input))
+  } catch (error) {
+    return handleError(error)
+  }
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string; commentId: string }> }
+) {
+  try {
+    const { id, commentId } = await params
+
+    return jsonNoStore(await deleteComment(id, commentId))
+  } catch (error) {
+    return handleError(error)
+  }
+}

--- a/src/app/api/posts/[id]/comments/comment-service.ts
+++ b/src/app/api/posts/[id]/comments/comment-service.ts
@@ -1,0 +1,159 @@
+import type { GoogleSpreadsheetRow } from "google-spreadsheet"
+
+import {
+  COMMENT_SHEET_HEADERS,
+  COMMENT_SHEET_TITLE,
+  type BlogComment,
+  type CommentInput,
+  sortCommentsByNewest,
+  validateCommentInput,
+} from "@/domains/blog/[uid]/comment-types"
+import { getOrCreateSheet } from "@/utils/spreadsheet"
+
+type CommentRow = {
+  "Comment Id": string
+  "Blog Id": string
+  Author: string
+  Content: string
+  "Created At": string
+  "Updated At": string
+}
+
+export class CommentServiceError extends Error {
+  status: number
+
+  constructor(message: string, status = 500) {
+    super(message)
+    this.name = "CommentServiceError"
+    this.status = status
+  }
+}
+
+async function getCommentSheet() {
+  return getOrCreateSheet(COMMENT_SHEET_TITLE, [...COMMENT_SHEET_HEADERS])
+}
+
+async function getCommentRows() {
+  const sheet = await getCommentSheet()
+  const rows = await sheet.getRows<CommentRow>()
+
+  return { sheet, rows }
+}
+
+function mapRowToComment(row: GoogleSpreadsheetRow<CommentRow>): BlogComment {
+  return {
+    id: row.get("Comment Id"),
+    postId: row.get("Blog Id"),
+    author: row.get("Author"),
+    content: row.get("Content"),
+    createdAt: row.get("Created At"),
+    updatedAt: row.get("Updated At") || null,
+  }
+}
+
+function filterRowsByPostId(
+  rows: GoogleSpreadsheetRow<CommentRow>[],
+  postId: string
+) {
+  return rows.filter((row) => row.get("Blog Id") === postId)
+}
+
+export async function listComments(postId: string) {
+  const { rows } = await getCommentRows()
+  const comments = sortCommentsByNewest(
+    filterRowsByPostId(rows, postId).map(mapRowToComment)
+  )
+
+  return {
+    postId,
+    count: comments.length,
+    comments,
+  }
+}
+
+export async function createComment(postId: string, input: CommentInput) {
+  const { author, content } = validateCommentInput(input)
+  const { sheet, rows } = await getCommentRows()
+  const currentCount = filterRowsByPostId(rows, postId).length
+  const timestamp = new Date().toISOString()
+  const comment: BlogComment = {
+    id: crypto.randomUUID(),
+    postId,
+    author,
+    content,
+    createdAt: timestamp,
+    updatedAt: null,
+  }
+
+  await sheet.addRow({
+    "Comment Id": comment.id,
+    "Blog Id": comment.postId,
+    Author: comment.author,
+    Content: comment.content,
+    "Created At": comment.createdAt,
+    "Updated At": "",
+  })
+
+  return {
+    postId,
+    count: currentCount + 1,
+    comment,
+  }
+}
+
+async function findCommentRow(postId: string, commentId: string) {
+  const { rows } = await getCommentRows()
+  const targetRow = rows.find(
+    (row) =>
+      row.get("Blog Id") === postId && row.get("Comment Id") === commentId
+  )
+
+  if (!targetRow) {
+    throw new CommentServiceError("댓글을 찾을 수 없습니다.", 404)
+  }
+
+  return {
+    rows,
+    targetRow,
+  }
+}
+
+export async function updateComment(
+  postId: string,
+  commentId: string,
+  input: CommentInput
+) {
+  const { author, content } = validateCommentInput(input)
+  const { targetRow } = await findCommentRow(postId, commentId)
+  const updatedAt = new Date().toISOString()
+
+  targetRow.set("Author", author)
+  targetRow.set("Content", content)
+  targetRow.set("Updated At", updatedAt)
+  await targetRow.save()
+
+  return {
+    postId,
+    comment: {
+      id: commentId,
+      postId,
+      author,
+      content,
+      createdAt: targetRow.get("Created At"),
+      updatedAt,
+    },
+  }
+}
+
+export async function deleteComment(postId: string, commentId: string) {
+  const { rows, targetRow } = await findCommentRow(postId, commentId)
+  const currentCount = filterRowsByPostId(rows, postId).length
+
+  await targetRow.delete()
+
+  return {
+    postId,
+    deletedCommentId: commentId,
+    count: Math.max(0, currentCount - 1),
+  }
+}

--- a/src/app/api/posts/[id]/comments/route.ts
+++ b/src/app/api/posts/[id]/comments/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from "next/server"
+
+import {
+  CommentValidationError,
+  type CommentInput,
+} from "@/domains/blog/[uid]/comment-types"
+
+import {
+  CommentServiceError,
+  createComment,
+  listComments,
+} from "./comment-service"
+
+export const dynamic = "force-dynamic"
+
+function jsonNoStore(body: unknown, status = 200) {
+  return NextResponse.json(body, {
+    status,
+    headers: {
+      "Cache-Control": "no-store",
+    },
+  })
+}
+
+function handleError(error: unknown) {
+  console.error("Comments API Error:", error)
+
+  if (error instanceof CommentValidationError) {
+    return jsonNoStore({ error: error.message }, 400)
+  }
+
+  if (error instanceof CommentServiceError) {
+    return jsonNoStore({ error: error.message }, error.status)
+  }
+
+  const message =
+    error instanceof Error ? error.message : "Internal Server Error"
+
+  return jsonNoStore(
+    {
+      error: "Google Sheets API와 통신 중 오류가 발생했습니다.",
+      details: message,
+    },
+    500
+  )
+}
+
+async function parseCommentInput(request: NextRequest) {
+  try {
+    return (await request.json()) as CommentInput
+  } catch {
+    throw new CommentServiceError("잘못된 요청입니다.", 400)
+  }
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params
+
+    return jsonNoStore(await listComments(id))
+  } catch (error) {
+    return handleError(error)
+  }
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params
+    const input = await parseCommentInput(request)
+
+    return jsonNoStore(await createComment(id, input))
+  } catch (error) {
+    return handleError(error)
+  }
+}

--- a/src/app/blog/[uid]/page.tsx
+++ b/src/app/blog/[uid]/page.tsx
@@ -7,6 +7,7 @@ import { createClient } from "@/prismicio"
 import { components } from "@/slices"
 import { Header } from "@/components/shared"
 import {
+  CommentsSection,
   GuiderunLink,
   LikeButton,
   TeamProfile,
@@ -61,6 +62,7 @@ export default async function BlogDetailPage({
           <div className="px-6 pb-6">
             <LikeButton id={uid} />
           </div>
+          <CommentsSection id={uid} />
           <GuiderunLink />
           <TeamProfile />
           <div className="flex justify-center">

--- a/src/domains/blog/[uid]/comment-form.tsx
+++ b/src/domains/blog/[uid]/comment-form.tsx
@@ -1,4 +1,4 @@
-import type { FormEvent } from "react"
+import { useEffect, useId, useRef, type FormEvent } from "react"
 
 import {
   COMMENT_AUTHOR_MAX_LENGTH,
@@ -8,10 +8,14 @@ import {
 interface CommentFormProps {
   author: string
   content: string
-  errorMessage: string | null
+  authorErrorMessage: string | null
+  contentErrorMessage: string | null
+  generalErrorMessage: string | null
   isEditing: boolean
   isSubmitDisabled: boolean
   isSubmitting: boolean
+  focusTarget: "author" | "content" | null
+  focusRequestToken: number
   onAuthorChange: (value: string) => void
   onContentChange: (value: string) => void
   onCancelEdit: VoidFunction
@@ -21,50 +25,132 @@ interface CommentFormProps {
 export const CommentForm = ({
   author,
   content,
-  errorMessage,
+  authorErrorMessage,
+  contentErrorMessage,
+  generalErrorMessage,
   isEditing,
   isSubmitDisabled,
   isSubmitting,
+  focusTarget,
+  focusRequestToken,
   onAuthorChange,
   onContentChange,
   onCancelEdit,
   onSubmit,
 }: CommentFormProps) => {
+  const authorInputRef = useRef<HTMLInputElement>(null)
+  const contentTextareaRef = useRef<HTMLTextAreaElement>(null)
+  const authorHelperId = useId()
+  const contentHelperId = useId()
+  const contentCounterId = useId()
+  const authorErrorId = useId()
+  const contentErrorId = useId()
+  const generalErrorId = useId()
   const contentLength = content.length
+  const remainingLength = COMMENT_CONTENT_MAX_LENGTH - contentLength
+  const counterAnnouncement =
+    contentLength === 0 ||
+    contentLength === COMMENT_CONTENT_MAX_LENGTH ||
+    remainingLength === 100 ||
+    remainingLength === 50 ||
+    remainingLength === 20 ||
+    remainingLength === 10 ||
+    remainingLength === 5
+      ? `현재 ${contentLength}자를 입력했습니다. 최대 ${COMMENT_CONTENT_MAX_LENGTH}자까지 입력할 수 있습니다.`
+      : ""
+  const authorDescribedBy = [
+    authorHelperId,
+    authorErrorMessage ? authorErrorId : null,
+    generalErrorMessage ? generalErrorId : null,
+  ]
+    .filter(Boolean)
+    .join(" ")
+  const contentDescribedBy = [
+    contentHelperId,
+    contentCounterId,
+    contentErrorMessage ? contentErrorId : null,
+    generalErrorMessage ? generalErrorId : null,
+  ]
+    .filter(Boolean)
+    .join(" ")
+
+  useEffect(() => {
+    if (focusTarget === "author") {
+      authorInputRef.current?.focus()
+    }
+
+    if (focusTarget === "content") {
+      contentTextareaRef.current?.focus()
+    }
+  }, [focusRequestToken, focusTarget])
 
   return (
     <form
       className="rounded-3xl border border-gray-200 bg-gray-50 px-5 py-5 md:px-6"
+      aria-busy={isSubmitting}
       onSubmit={onSubmit}>
       <div className="flex flex-col gap-4">
         <label className="flex flex-col gap-2">
           <span className="text-sm font-semibold text-gray-700">작성자</span>
           <input
+            ref={authorInputRef}
             value={author}
             maxLength={COMMENT_AUTHOR_MAX_LENGTH}
             onChange={(event) => onAuthorChange(event.target.value)}
-            className="rounded-2xl border border-gray-200 bg-white px-4 py-3 text-[0.95rem] text-gray-900 transition-colors outline-none focus:border-gray-400"
+            aria-invalid={authorErrorMessage ? true : undefined}
+            aria-describedby={authorDescribedBy}
+            className="rounded-2xl border border-gray-200 bg-white px-4 py-3 text-[0.95rem] text-gray-900 transition-colors outline-none focus:border-gray-400 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-900"
           />
+          <span id={authorHelperId} className="sr-only">
+            작성자를 비워두면 익명의 러너로 저장됩니다. 최대 20자까지 입력할 수
+            있습니다.
+          </span>
+          {authorErrorMessage && (
+            <p id={authorErrorId} className="text-sm text-red-500" role="alert">
+              {authorErrorMessage}
+            </p>
+          )}
         </label>
         <label className="flex flex-col gap-2">
           <span className="text-sm font-semibold text-gray-700">댓글</span>
           <textarea
+            ref={contentTextareaRef}
             value={content}
             maxLength={COMMENT_CONTENT_MAX_LENGTH}
             onChange={(event) => onContentChange(event.target.value)}
             rows={5}
-            className="min-h-[144px] resize-y rounded-2xl border border-gray-200 bg-white px-4 py-3 text-[0.95rem] leading-7 text-gray-900 transition-colors outline-none focus:border-gray-400"
-            placeholder="서로를 존중하는 댓글을 남겨주세요."
+            aria-invalid={contentErrorMessage ? true : undefined}
+            aria-describedby={contentDescribedBy}
+            className="min-h-[144px] resize-y rounded-2xl border border-gray-200 bg-white px-4 py-3 text-[0.95rem] leading-7 text-gray-900 transition-colors outline-none focus:border-gray-400 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-900"
+            placeholder="댓글을 입력해주세요. 최대 500자까지 작성할 수 있어요."
           />
+          <span id={contentHelperId} className="sr-only">
+            댓글은 최대 500자까지 입력할 수 있습니다.
+          </span>
+          {contentErrorMessage && (
+            <p
+              id={contentErrorId}
+              className="text-sm text-red-500"
+              role="alert">
+              {contentErrorMessage}
+            </p>
+          )}
         </label>
       </div>
-      {errorMessage && (
-        <p className="mt-3 text-sm text-red-500" role="alert">
-          {errorMessage}
+      {generalErrorMessage && (
+        <p
+          id={generalErrorId}
+          className="mt-3 text-sm text-red-500"
+          role="alert">
+          {generalErrorMessage}
         </p>
       )}
+      <p className="sr-only" aria-live="polite" aria-atomic="true">
+        {counterAnnouncement}
+      </p>
       <div className="mt-4 flex flex-wrap items-end justify-between gap-3">
         <p
+          id={contentCounterId}
           className={`text-sm ${contentLength > COMMENT_CONTENT_MAX_LENGTH ? "text-red-500" : "text-gray-400"}`}>
           {contentLength} / {COMMENT_CONTENT_MAX_LENGTH}
         </p>
@@ -72,7 +158,7 @@ export const CommentForm = ({
           {isEditing && (
             <button
               type="button"
-              className="rounded-full border border-gray-200 bg-white px-4 py-2.5 text-sm font-semibold text-gray-700 transition-colors hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
+              className="rounded-full border border-gray-200 bg-white px-4 py-2.5 text-sm font-semibold text-gray-700 transition-colors outline-none hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-900 disabled:cursor-not-allowed disabled:opacity-50"
               onClick={onCancelEdit}
               disabled={isSubmitting}>
               취소
@@ -80,7 +166,7 @@ export const CommentForm = ({
           )}
           <button
             type="submit"
-            className="rounded-full bg-gray-900 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-gray-700 disabled:cursor-not-allowed disabled:bg-gray-400"
+            className="rounded-full bg-gray-900 px-5 py-2.5 text-sm font-semibold text-white transition-colors outline-none hover:bg-gray-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-900 disabled:cursor-not-allowed disabled:bg-gray-400"
             disabled={isSubmitDisabled}>
             {isEditing ? "수정하기" : "댓글 남기기"}
           </button>

--- a/src/domains/blog/[uid]/comment-form.tsx
+++ b/src/domains/blog/[uid]/comment-form.tsx
@@ -1,0 +1,91 @@
+import type { FormEvent } from "react"
+
+import {
+  COMMENT_AUTHOR_MAX_LENGTH,
+  COMMENT_CONTENT_MAX_LENGTH,
+} from "./comment-types"
+
+interface CommentFormProps {
+  author: string
+  content: string
+  errorMessage: string | null
+  isEditing: boolean
+  isSubmitDisabled: boolean
+  isSubmitting: boolean
+  onAuthorChange: (value: string) => void
+  onContentChange: (value: string) => void
+  onCancelEdit: VoidFunction
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void
+}
+
+export const CommentForm = ({
+  author,
+  content,
+  errorMessage,
+  isEditing,
+  isSubmitDisabled,
+  isSubmitting,
+  onAuthorChange,
+  onContentChange,
+  onCancelEdit,
+  onSubmit,
+}: CommentFormProps) => {
+  const contentLength = content.length
+
+  return (
+    <form
+      className="rounded-3xl border border-gray-200 bg-gray-50 px-5 py-5 md:px-6"
+      onSubmit={onSubmit}>
+      <div className="flex flex-col gap-4">
+        <label className="flex flex-col gap-2">
+          <span className="text-sm font-semibold text-gray-700">작성자</span>
+          <input
+            value={author}
+            maxLength={COMMENT_AUTHOR_MAX_LENGTH}
+            onChange={(event) => onAuthorChange(event.target.value)}
+            className="rounded-2xl border border-gray-200 bg-white px-4 py-3 text-[0.95rem] text-gray-900 transition-colors outline-none focus:border-gray-400"
+          />
+        </label>
+        <label className="flex flex-col gap-2">
+          <span className="text-sm font-semibold text-gray-700">댓글</span>
+          <textarea
+            value={content}
+            maxLength={COMMENT_CONTENT_MAX_LENGTH}
+            onChange={(event) => onContentChange(event.target.value)}
+            rows={5}
+            className="min-h-[144px] resize-y rounded-2xl border border-gray-200 bg-white px-4 py-3 text-[0.95rem] leading-7 text-gray-900 transition-colors outline-none focus:border-gray-400"
+            placeholder="서로를 존중하는 댓글을 남겨주세요."
+          />
+        </label>
+      </div>
+      {errorMessage && (
+        <p className="mt-3 text-sm text-red-500" role="alert">
+          {errorMessage}
+        </p>
+      )}
+      <div className="mt-4 flex flex-wrap items-end justify-between gap-3">
+        <p
+          className={`text-sm ${contentLength > COMMENT_CONTENT_MAX_LENGTH ? "text-red-500" : "text-gray-400"}`}>
+          {contentLength} / {COMMENT_CONTENT_MAX_LENGTH}
+        </p>
+        <div className="flex items-center gap-2">
+          {isEditing && (
+            <button
+              type="button"
+              className="rounded-full border border-gray-200 bg-white px-4 py-2.5 text-sm font-semibold text-gray-700 transition-colors hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
+              onClick={onCancelEdit}
+              disabled={isSubmitting}>
+              취소
+            </button>
+          )}
+          <button
+            type="submit"
+            className="rounded-full bg-gray-900 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-gray-700 disabled:cursor-not-allowed disabled:bg-gray-400"
+            disabled={isSubmitDisabled}>
+            {isEditing ? "수정하기" : "댓글 남기기"}
+          </button>
+        </div>
+      </div>
+    </form>
+  )
+}

--- a/src/domains/blog/[uid]/comment-item.tsx
+++ b/src/domains/blog/[uid]/comment-item.tsx
@@ -2,6 +2,7 @@ import type { BlogComment } from "./comment-types"
 
 interface CommentItemProps {
   comment: BlogComment
+  elementId: string
   isOwned: boolean
   isActionDisabled: boolean
   isDeleting: boolean
@@ -28,6 +29,7 @@ function formatCommentDate(value: string) {
 
 export const CommentItem = ({
   comment,
+  elementId,
   isOwned,
   isActionDisabled,
   isDeleting,
@@ -37,7 +39,10 @@ export const CommentItem = ({
   const formattedDate = formatCommentDate(comment.createdAt)
 
   return (
-    <li className="py-5 first:pt-0 last:pb-0">
+    <li
+      id={elementId}
+      tabIndex={-1}
+      className="py-5 outline-none first:pt-0 last:pb-0 focus:outline-2 focus:outline-offset-2 focus:outline-gray-900">
       <div className="flex items-start justify-between gap-4">
         <div className="min-w-0">
           <div className="flex flex-wrap items-center gap-2">
@@ -56,14 +61,16 @@ export const CommentItem = ({
           <div className="flex shrink-0 items-center gap-3 text-sm">
             <button
               type="button"
-              className="text-gray-500 transition-colors hover:text-gray-800 disabled:cursor-not-allowed disabled:text-gray-300"
+              aria-label={`${comment.author} 댓글 수정`}
+              className="text-gray-500 transition-colors outline-none hover:text-gray-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-900 disabled:cursor-not-allowed disabled:text-gray-300"
               onClick={() => onEdit(comment)}
               disabled={isActionDisabled}>
               수정
             </button>
             <button
               type="button"
-              className="text-gray-500 transition-colors hover:text-gray-800 disabled:cursor-not-allowed disabled:text-gray-300"
+              aria-label={`${comment.author} 댓글 삭제`}
+              className="text-gray-500 transition-colors outline-none hover:text-gray-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-900 disabled:cursor-not-allowed disabled:text-gray-300"
               onClick={() => onDelete(comment.id)}
               disabled={isActionDisabled}>
               {isDeleting ? "삭제 중..." : "삭제"}

--- a/src/domains/blog/[uid]/comment-item.tsx
+++ b/src/domains/blog/[uid]/comment-item.tsx
@@ -1,0 +1,79 @@
+import type { BlogComment } from "./comment-types"
+
+interface CommentItemProps {
+  comment: BlogComment
+  isOwned: boolean
+  isActionDisabled: boolean
+  isDeleting: boolean
+  onEdit: (comment: BlogComment) => void
+  onDelete: (commentId: string) => void
+}
+
+function formatCommentDate(value: string) {
+  const date = new Date(value)
+
+  if (Number.isNaN(date.getTime())) {
+    return ""
+  }
+
+  return new Intl.DateTimeFormat("ko-KR", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).format(date)
+}
+
+export const CommentItem = ({
+  comment,
+  isOwned,
+  isActionDisabled,
+  isDeleting,
+  onEdit,
+  onDelete,
+}: CommentItemProps) => {
+  const formattedDate = formatCommentDate(comment.createdAt)
+
+  return (
+    <li className="py-5 first:pt-0 last:pb-0">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <strong className="text-[0.95rem] text-gray-900">
+              {comment.author}
+            </strong>
+            {formattedDate && (
+              <span className="text-sm text-gray-400">{formattedDate}</span>
+            )}
+            {comment.updatedAt && (
+              <span className="text-sm text-gray-400">수정됨</span>
+            )}
+          </div>
+        </div>
+        {isOwned && (
+          <div className="flex shrink-0 items-center gap-3 text-sm">
+            <button
+              type="button"
+              className="text-gray-500 transition-colors hover:text-gray-800 disabled:cursor-not-allowed disabled:text-gray-300"
+              onClick={() => onEdit(comment)}
+              disabled={isActionDisabled}>
+              수정
+            </button>
+            <button
+              type="button"
+              className="text-gray-500 transition-colors hover:text-gray-800 disabled:cursor-not-allowed disabled:text-gray-300"
+              onClick={() => onDelete(comment.id)}
+              disabled={isActionDisabled}>
+              {isDeleting ? "삭제 중..." : "삭제"}
+            </button>
+          </div>
+        )}
+      </div>
+      <p className="mt-3 text-[0.95rem] leading-7 whitespace-pre-line text-gray-700">
+        {comment.content}
+      </p>
+    </li>
+  )
+}

--- a/src/domains/blog/[uid]/comment-types.ts
+++ b/src/domains/blog/[uid]/comment-types.ts
@@ -1,0 +1,111 @@
+export type BlogComment = {
+  id: string
+  postId: string
+  author: string
+  content: string
+  createdAt: string
+  updatedAt: string | null
+}
+
+export type OwnedCommentMap = Record<string, string[]>
+
+export type CommentInput = {
+  author?: string
+  content: string
+}
+
+export type CommentsResponse = {
+  postId: string
+  count: number
+  comments: BlogComment[]
+}
+
+export type CreateCommentResponse = {
+  postId: string
+  count: number
+  comment: BlogComment
+}
+
+export type UpdateCommentResponse = {
+  postId: string
+  comment: BlogComment
+}
+
+export type DeleteCommentResponse = {
+  postId: string
+  deletedCommentId: string
+  count: number
+}
+
+export const DEFAULT_COMMENT_AUTHOR = "익명의 러너"
+export const COMMENT_AUTHOR_MAX_LENGTH = 20
+export const COMMENT_CONTENT_MAX_LENGTH = 500
+export const BLOG_COMMENT_IDS_STORAGE_KEY = "BLOG_COMMENT_IDS"
+export const COMMENT_SHEET_TITLE = "comments"
+export const COMMENT_SHEET_HEADERS = [
+  "Comment Id",
+  "Blog Id",
+  "Author",
+  "Content",
+  "Created At",
+  "Updated At",
+] as const
+
+export class CommentValidationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "CommentValidationError"
+  }
+}
+
+export function normalizeCommentAuthor(author?: string | null) {
+  const normalizedAuthor = author?.trim() ?? ""
+
+  if (!normalizedAuthor) {
+    return DEFAULT_COMMENT_AUTHOR
+  }
+
+  return normalizedAuthor
+}
+
+export function normalizeCommentContent(content?: string | null) {
+  return content?.trim() ?? ""
+}
+
+export function validateCommentInput(input: {
+  author?: string | null
+  content?: string | null
+}) {
+  const author = normalizeCommentAuthor(input.author)
+  const content = normalizeCommentContent(input.content)
+
+  if (author.length > COMMENT_AUTHOR_MAX_LENGTH) {
+    throw new CommentValidationError(
+      `작성자는 ${COMMENT_AUTHOR_MAX_LENGTH}자 이하로 입력해주세요.`
+    )
+  }
+
+  if (!content) {
+    throw new CommentValidationError("댓글 내용을 입력해주세요.")
+  }
+
+  if (content.length > COMMENT_CONTENT_MAX_LENGTH) {
+    throw new CommentValidationError(
+      `댓글은 ${COMMENT_CONTENT_MAX_LENGTH}자 이하로 입력해주세요.`
+    )
+  }
+
+  return {
+    author,
+    content,
+  }
+}
+
+export function sortCommentsByNewest(comments: BlogComment[]) {
+  return [...comments].sort((left, right) => {
+    const leftTime = new Date(left.createdAt).getTime()
+    const rightTime = new Date(right.createdAt).getTime()
+
+    return rightTime - leftTime
+  })
+}

--- a/src/domains/blog/[uid]/comments-section.tsx
+++ b/src/domains/blog/[uid]/comments-section.tsx
@@ -1,0 +1,321 @@
+"use client"
+
+import axios from "axios"
+import type { FormEvent } from "react"
+import { useEffect, useState } from "react"
+
+import { CommentForm } from "./comment-form"
+import { CommentItem } from "./comment-item"
+import {
+  BLOG_COMMENT_IDS_STORAGE_KEY,
+  COMMENT_AUTHOR_MAX_LENGTH,
+  COMMENT_CONTENT_MAX_LENGTH,
+  DEFAULT_COMMENT_AUTHOR,
+  CommentValidationError,
+  type BlogComment,
+  type CommentsResponse,
+  type CreateCommentResponse,
+  type DeleteCommentResponse,
+  type OwnedCommentMap,
+  type UpdateCommentResponse,
+  sortCommentsByNewest,
+  validateCommentInput,
+} from "./comment-types"
+
+interface CommentsSectionProps {
+  id: string
+}
+
+function getErrorMessage(error: unknown) {
+  if (axios.isAxiosError(error)) {
+    return (
+      error.response?.data?.error ?? "오류가 발생했습니다. 다시 시도해주세요."
+    )
+  }
+
+  if (error instanceof Error) {
+    return error.message
+  }
+
+  return "오류가 발생했습니다. 다시 시도해주세요."
+}
+
+function readOwnedCommentMap() {
+  if (typeof window === "undefined") {
+    return {}
+  }
+
+  try {
+    const storedValue = localStorage.getItem(BLOG_COMMENT_IDS_STORAGE_KEY)
+
+    if (!storedValue) {
+      return {}
+    }
+
+    const parsedValue = JSON.parse(storedValue)
+
+    if (
+      !parsedValue ||
+      typeof parsedValue !== "object" ||
+      Array.isArray(parsedValue)
+    ) {
+      return {}
+    }
+
+    return Object.fromEntries(
+      Object.entries(parsedValue).map(([postId, commentIds]) => [
+        postId,
+        Array.isArray(commentIds)
+          ? Array.from(
+              new Set(
+                commentIds.filter(
+                  (commentId): commentId is string =>
+                    typeof commentId === "string" && commentId.length > 0
+                )
+              )
+            )
+          : [],
+      ])
+    ) as OwnedCommentMap
+  } catch {
+    return {}
+  }
+}
+
+function persistOwnedCommentIds(postId: string, commentIds: string[]) {
+  const ownedCommentMap = readOwnedCommentMap()
+  const nextCommentIds = Array.from(new Set(commentIds))
+
+  if (nextCommentIds.length > 0) {
+    ownedCommentMap[postId] = nextCommentIds
+  } else {
+    delete ownedCommentMap[postId]
+  }
+
+  localStorage.setItem(
+    BLOG_COMMENT_IDS_STORAGE_KEY,
+    JSON.stringify(ownedCommentMap)
+  )
+
+  return nextCommentIds
+}
+
+export const CommentsSection = ({ id }: CommentsSectionProps) => {
+  const commentsEndpoint = `/api/posts/${id}/comments`
+
+  const [comments, setComments] = useState<BlogComment[]>([])
+  const [author, setAuthor] = useState(DEFAULT_COMMENT_AUTHOR)
+  const [content, setContent] = useState("")
+  const [ownedCommentIds, setOwnedCommentIds] = useState<string[]>([])
+  const [editingCommentId, setEditingCommentId] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [formError, setFormError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null)
+  const [reloadToken, setReloadToken] = useState(0)
+
+  const resetForm = () => {
+    setAuthor(DEFAULT_COMMENT_AUTHOR)
+    setContent("")
+    setEditingCommentId(null)
+    setFormError(null)
+  }
+
+  useEffect(() => {
+    setOwnedCommentIds(readOwnedCommentMap()[id] ?? [])
+  }, [id])
+
+  useEffect(() => {
+    let isCancelled = false
+
+    const fetchComments = async () => {
+      setIsLoading(true)
+      setLoadError(null)
+
+      try {
+        const response = await axios.get<CommentsResponse>(commentsEndpoint)
+
+        if (!isCancelled) {
+          setComments(sortCommentsByNewest(response.data.comments))
+        }
+      } catch (error) {
+        if (!isCancelled) {
+          setLoadError(getErrorMessage(error))
+        }
+      } finally {
+        if (!isCancelled) {
+          setIsLoading(false)
+        }
+      }
+    }
+
+    void fetchComments()
+
+    return () => {
+      isCancelled = true
+    }
+  }, [commentsEndpoint, id, reloadToken])
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    if (isSubmitting) {
+      return
+    }
+
+    try {
+      const payload = validateCommentInput({ author, content })
+
+      setIsSubmitting(true)
+      setFormError(null)
+
+      if (editingCommentId) {
+        const response = await axios.patch<UpdateCommentResponse>(
+          `${commentsEndpoint}/${editingCommentId}`,
+          payload
+        )
+
+        setComments((prevComments) =>
+          sortCommentsByNewest(
+            prevComments.map((comment) =>
+              comment.id === editingCommentId ? response.data.comment : comment
+            )
+          )
+        )
+        resetForm()
+        return
+      }
+
+      const response = await axios.post<CreateCommentResponse>(
+        commentsEndpoint,
+        payload
+      )
+
+      setComments((prevComments) =>
+        sortCommentsByNewest([response.data.comment, ...prevComments])
+      )
+      setOwnedCommentIds((prevCommentIds) =>
+        persistOwnedCommentIds(id, [
+          ...prevCommentIds,
+          response.data.comment.id,
+        ])
+      )
+      resetForm()
+    } catch (error) {
+      if (error instanceof CommentValidationError) {
+        setFormError(error.message)
+      } else {
+        setFormError(getErrorMessage(error))
+      }
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const handleEdit = (comment: BlogComment) => {
+    setEditingCommentId(comment.id)
+    setAuthor(comment.author)
+    setContent(comment.content)
+    setFormError(null)
+  }
+
+  const handleDelete = async (commentId: string) => {
+    if (!window.confirm("댓글을 삭제할까요?")) {
+      return
+    }
+
+    try {
+      setPendingDeleteId(commentId)
+
+      await axios.delete<DeleteCommentResponse>(
+        `${commentsEndpoint}/${commentId}`
+      )
+
+      setComments((prevComments) =>
+        prevComments.filter((comment) => comment.id !== commentId)
+      )
+      setOwnedCommentIds((prevCommentIds) =>
+        persistOwnedCommentIds(
+          id,
+          prevCommentIds.filter(
+            (storedCommentId) => storedCommentId !== commentId
+          )
+        )
+      )
+
+      if (editingCommentId === commentId) {
+        resetForm()
+      }
+    } catch (error) {
+      alert(getErrorMessage(error))
+    } finally {
+      setPendingDeleteId(null)
+    }
+  }
+
+  const isSubmitDisabled =
+    isSubmitting ||
+    !content.trim() ||
+    content.length > COMMENT_CONTENT_MAX_LENGTH ||
+    author.trim().length > COMMENT_AUTHOR_MAX_LENGTH
+
+  return (
+    <section className="px-6 pb-10">
+      <div className="mb-5">
+        <h2 className="text-[1.625rem] font-bold text-gray-900">
+          댓글 {comments.length}
+        </h2>
+        <p className="mt-2 text-sm text-gray-500">
+          서로를 존중하는 댓글을 남겨주세요.
+        </p>
+      </div>
+      <CommentForm
+        author={author}
+        content={content}
+        errorMessage={formError}
+        isEditing={editingCommentId !== null}
+        isSubmitDisabled={isSubmitDisabled}
+        isSubmitting={isSubmitting}
+        onAuthorChange={setAuthor}
+        onContentChange={setContent}
+        onCancelEdit={resetForm}
+        onSubmit={handleSubmit}
+      />
+      <div className="mt-8">
+        {loadError && (
+          <div className="rounded-2xl border border-red-100 bg-red-50 px-4 py-3 text-sm text-red-600">
+            <p>{loadError}</p>
+            <button
+              type="button"
+              className="mt-3 font-semibold underline underline-offset-4"
+              onClick={() => setReloadToken((prevToken) => prevToken + 1)}>
+              다시 시도
+            </button>
+          </div>
+        )}
+        {!loadError && isLoading && (
+          <p className="py-6 text-sm text-gray-400">불러오는 중...</p>
+        )}
+        {!isLoading && comments.length === 0 && !loadError && (
+          <p className="py-6 text-sm text-gray-400">첫 댓글을 남겨보세요.</p>
+        )}
+        {comments.length > 0 && (
+          <ul className="divide-y divide-gray-200">
+            {comments.map((comment) => (
+              <CommentItem
+                key={comment.id}
+                comment={comment}
+                isOwned={ownedCommentIds.includes(comment.id)}
+                isActionDisabled={isSubmitting || pendingDeleteId !== null}
+                isDeleting={pendingDeleteId === comment.id}
+                onEdit={handleEdit}
+                onDelete={handleDelete}
+              />
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/src/domains/blog/[uid]/comments-section.tsx
+++ b/src/domains/blog/[uid]/comments-section.tsx
@@ -106,6 +106,16 @@ function persistOwnedCommentIds(postId: string, commentIds: string[]) {
   return nextCommentIds
 }
 
+function replaceCommentId(
+  commentIds: string[],
+  previousId: string,
+  nextId: string
+) {
+  return commentIds.map((commentId) =>
+    commentId === previousId ? nextId : commentId
+  )
+}
+
 export const CommentsSection = ({ id }: CommentsSectionProps) => {
   const commentsEndpoint = `/api/posts/${id}/comments`
   const headingRef = useRef<HTMLHeadingElement>(null)
@@ -225,48 +235,134 @@ export const CommentsSection = ({ id }: CommentsSectionProps) => {
 
     try {
       const payload = validateCommentInput({ author, content })
+      const formSnapshot = { author, content }
 
       setIsSubmitting(true)
       setFormError(null)
 
       if (editingCommentId) {
-        const response = await axios.patch<UpdateCommentResponse>(
-          `${commentsEndpoint}/${editingCommentId}`,
+        const previousComments = comments
+        const originalComment = comments.find(
+          (comment) => comment.id === editingCommentId
+        )
+
+        if (!originalComment) {
+          throw new Error("댓글을 찾을 수 없습니다.")
+        }
+
+        const optimisticComment: BlogComment = {
+          ...originalComment,
+          author: payload.author,
+          content: payload.content,
+          updatedAt: new Date().toISOString(),
+        }
+
+        setComments((prevComments) =>
+          sortCommentsByNewest(
+            prevComments.map((comment) =>
+              comment.id === editingCommentId ? optimisticComment : comment
+            )
+          )
+        )
+        resetForm()
+        announce("댓글을 저장하고 있습니다.")
+
+        try {
+          const response = await axios.patch<UpdateCommentResponse>(
+            `${commentsEndpoint}/${editingCommentId}`,
+            payload
+          )
+
+          setComments((prevComments) =>
+            sortCommentsByNewest(
+              prevComments.map((comment) =>
+                comment.id === editingCommentId
+                  ? response.data.comment
+                  : comment
+              )
+            )
+          )
+          setPendingFocusCommentId(response.data.comment.id)
+          announce("댓글이 수정되었습니다.")
+        } catch (error) {
+          const message = getErrorMessage(error)
+
+          setComments(previousComments)
+          setEditingCommentId(originalComment.id)
+          setAuthor(formSnapshot.author)
+          setContent(formSnapshot.content)
+          setFormError(message)
+          announce(message, "assertive")
+          requestFormFocus("content")
+        } finally {
+          setIsSubmitting(false)
+        }
+
+        return
+      }
+
+      const previousComments = comments
+      const previousOwnedCommentIds = ownedCommentIds
+      const optimisticCommentId = `temp-${crypto.randomUUID()}`
+      const nextCommentCount = comments.length + 1
+      const optimisticComment: BlogComment = {
+        id: optimisticCommentId,
+        postId: id,
+        author: payload.author,
+        content: payload.content,
+        createdAt: new Date().toISOString(),
+        updatedAt: null,
+      }
+
+      setComments((prevComments) =>
+        sortCommentsByNewest([optimisticComment, ...prevComments])
+      )
+      setOwnedCommentIds((prevCommentIds) =>
+        persistOwnedCommentIds(id, [...prevCommentIds, optimisticCommentId])
+      )
+      resetForm()
+      requestFormFocus("content")
+      announce("댓글을 저장하고 있습니다.")
+
+      try {
+        const response = await axios.post<CreateCommentResponse>(
+          commentsEndpoint,
           payload
         )
 
         setComments((prevComments) =>
           sortCommentsByNewest(
             prevComments.map((comment) =>
-              comment.id === editingCommentId ? response.data.comment : comment
+              comment.id === optimisticCommentId
+                ? response.data.comment
+                : comment
             )
           )
         )
-        setPendingFocusCommentId(response.data.comment.id)
-        announce("댓글이 수정되었습니다.")
-        resetForm()
-        return
+        setOwnedCommentIds((prevCommentIds) =>
+          persistOwnedCommentIds(
+            id,
+            replaceCommentId(
+              prevCommentIds,
+              optimisticCommentId,
+              response.data.comment.id
+            )
+          )
+        )
+        announce(
+          `댓글이 등록되었습니다. 현재 댓글은 ${nextCommentCount}개입니다.`
+        )
+      } catch (error) {
+        const message = getErrorMessage(error)
+
+        setComments(previousComments)
+        setOwnedCommentIds(persistOwnedCommentIds(id, previousOwnedCommentIds))
+        setAuthor(formSnapshot.author)
+        setContent(formSnapshot.content)
+        setFormError(message)
+        announce(message, "assertive")
+        requestFormFocus("content")
       }
-
-      const response = await axios.post<CreateCommentResponse>(
-        commentsEndpoint,
-        payload
-      )
-
-      setComments((prevComments) =>
-        sortCommentsByNewest([response.data.comment, ...prevComments])
-      )
-      setOwnedCommentIds((prevCommentIds) =>
-        persistOwnedCommentIds(id, [
-          ...prevCommentIds,
-          response.data.comment.id,
-        ])
-      )
-      setPendingFocusCommentId(response.data.comment.id)
-      announce(
-        `댓글이 등록되었습니다. 현재 댓글은 ${comments.length + 1}개입니다.`
-      )
-      resetForm()
     } catch (error) {
       if (error instanceof CommentValidationError) {
         setFormError(error.message)
@@ -299,13 +395,18 @@ export const CommentsSection = ({ id }: CommentsSectionProps) => {
       return
     }
 
+    const previousComments = comments
+    const previousOwnedCommentIds = ownedCommentIds
+    const deletedComment = comments.find((comment) => comment.id === commentId)
+    const wasEditingComment = editingCommentId === commentId
+
+    if (!deletedComment) {
+      announce("댓글을 찾을 수 없습니다.", "assertive")
+      return
+    }
+
     try {
       setPendingDeleteId(commentId)
-
-      await axios.delete<DeleteCommentResponse>(
-        `${commentsEndpoint}/${commentId}`
-      )
-
       setComments((prevComments) =>
         prevComments.filter((comment) => comment.id !== commentId)
       )
@@ -317,16 +418,36 @@ export const CommentsSection = ({ id }: CommentsSectionProps) => {
           )
         )
       )
-      announce(
-        `댓글이 삭제되었습니다. 현재 댓글은 ${Math.max(0, comments.length - 1)}개입니다.`
-      )
-      headingRef.current?.focus()
 
-      if (editingCommentId === commentId) {
+      if (wasEditingComment) {
         resetForm()
       }
+      headingRef.current?.focus()
+      announce("댓글을 삭제하고 있습니다.")
+
+      await axios.delete<DeleteCommentResponse>(
+        `${commentsEndpoint}/${commentId}`
+      )
+
+      announce(
+        `댓글이 삭제되었습니다. 현재 댓글은 ${Math.max(0, previousComments.length - 1)}개입니다.`
+      )
     } catch (error) {
-      announce(getErrorMessage(error), "assertive")
+      const message = getErrorMessage(error)
+
+      setComments(previousComments)
+      setOwnedCommentIds(persistOwnedCommentIds(id, previousOwnedCommentIds))
+
+      if (wasEditingComment) {
+        setEditingCommentId(deletedComment.id)
+        setAuthor(deletedComment.author)
+        setContent(deletedComment.content)
+        requestFormFocus("content")
+      } else {
+        setPendingFocusCommentId(deletedComment.id)
+      }
+
+      announce(message, "assertive")
     } finally {
       setPendingDeleteId(null)
     }

--- a/src/domains/blog/[uid]/comments-section.tsx
+++ b/src/domains/blog/[uid]/comments-section.tsx
@@ -2,7 +2,7 @@
 
 import axios from "axios"
 import type { FormEvent } from "react"
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 
 import { CommentForm } from "./comment-form"
 import { CommentItem } from "./comment-item"
@@ -24,6 +24,12 @@ import {
 
 interface CommentsSectionProps {
   id: string
+}
+
+type Announcement = {
+  id: number
+  politeness: "polite" | "assertive"
+  message: string
 }
 
 function getErrorMessage(error: unknown) {
@@ -102,6 +108,7 @@ function persistOwnedCommentIds(postId: string, commentIds: string[]) {
 
 export const CommentsSection = ({ id }: CommentsSectionProps) => {
   const commentsEndpoint = `/api/posts/${id}/comments`
+  const headingRef = useRef<HTMLHeadingElement>(null)
 
   const [comments, setComments] = useState<BlogComment[]>([])
   const [author, setAuthor] = useState(DEFAULT_COMMENT_AUTHOR)
@@ -114,6 +121,40 @@ export const CommentsSection = ({ id }: CommentsSectionProps) => {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null)
   const [reloadToken, setReloadToken] = useState(0)
+  const [focusRequestToken, setFocusRequestToken] = useState(0)
+  const [focusTarget, setFocusTarget] = useState<"author" | "content" | null>(
+    null
+  )
+  const [pendingFocusCommentId, setPendingFocusCommentId] = useState<
+    string | null
+  >(null)
+  const [announcement, setAnnouncement] = useState<Announcement | null>(null)
+
+  const authorErrorMessage = formError?.startsWith("작성자는")
+    ? formError
+    : null
+  const contentErrorMessage =
+    formError === "댓글 내용을 입력해주세요." || formError?.startsWith("댓글은")
+      ? formError
+      : null
+  const generalErrorMessage =
+    formError && !authorErrorMessage && !contentErrorMessage ? formError : null
+
+  const announce = (
+    message: string,
+    politeness: Announcement["politeness"] = "polite"
+  ) => {
+    setAnnouncement({
+      id: Date.now(),
+      politeness,
+      message,
+    })
+  }
+
+  const requestFormFocus = (target: "author" | "content") => {
+    setFocusTarget(target)
+    setFocusRequestToken((prevToken) => prevToken + 1)
+  }
 
   const resetForm = () => {
     setAuthor(DEFAULT_COMMENT_AUTHOR)
@@ -121,6 +162,22 @@ export const CommentsSection = ({ id }: CommentsSectionProps) => {
     setEditingCommentId(null)
     setFormError(null)
   }
+
+  useEffect(() => {
+    if (!pendingFocusCommentId) {
+      return
+    }
+
+    const frameId = window.requestAnimationFrame(() => {
+      document.getElementById(`comment-item-${pendingFocusCommentId}`)?.focus()
+    })
+
+    setPendingFocusCommentId(null)
+
+    return () => {
+      window.cancelAnimationFrame(frameId)
+    }
+  }, [comments, pendingFocusCommentId])
 
   useEffect(() => {
     setOwnedCommentIds(readOwnedCommentMap()[id] ?? [])
@@ -141,7 +198,9 @@ export const CommentsSection = ({ id }: CommentsSectionProps) => {
         }
       } catch (error) {
         if (!isCancelled) {
-          setLoadError(getErrorMessage(error))
+          const message = getErrorMessage(error)
+          setLoadError(message)
+          announce(message, "assertive")
         }
       } finally {
         if (!isCancelled) {
@@ -183,6 +242,8 @@ export const CommentsSection = ({ id }: CommentsSectionProps) => {
             )
           )
         )
+        setPendingFocusCommentId(response.data.comment.id)
+        announce("댓글이 수정되었습니다.")
         resetForm()
         return
       }
@@ -201,12 +262,23 @@ export const CommentsSection = ({ id }: CommentsSectionProps) => {
           response.data.comment.id,
         ])
       )
+      setPendingFocusCommentId(response.data.comment.id)
+      announce(
+        `댓글이 등록되었습니다. 현재 댓글은 ${comments.length + 1}개입니다.`
+      )
       resetForm()
     } catch (error) {
       if (error instanceof CommentValidationError) {
         setFormError(error.message)
+        announce(error.message, "assertive")
+        requestFormFocus(
+          error.message.startsWith("작성자는") ? "author" : "content"
+        )
       } else {
-        setFormError(getErrorMessage(error))
+        const message = getErrorMessage(error)
+        setFormError(message)
+        announce(message, "assertive")
+        requestFormFocus("content")
       }
     } finally {
       setIsSubmitting(false)
@@ -218,6 +290,8 @@ export const CommentsSection = ({ id }: CommentsSectionProps) => {
     setAuthor(comment.author)
     setContent(comment.content)
     setFormError(null)
+    requestFormFocus("content")
+    announce(`${comment.author} 댓글 수정 모드입니다.`)
   }
 
   const handleDelete = async (commentId: string) => {
@@ -243,12 +317,16 @@ export const CommentsSection = ({ id }: CommentsSectionProps) => {
           )
         )
       )
+      announce(
+        `댓글이 삭제되었습니다. 현재 댓글은 ${Math.max(0, comments.length - 1)}개입니다.`
+      )
+      headingRef.current?.focus()
 
       if (editingCommentId === commentId) {
         resetForm()
       }
     } catch (error) {
-      alert(getErrorMessage(error))
+      announce(getErrorMessage(error), "assertive")
     } finally {
       setPendingDeleteId(null)
     }
@@ -261,22 +339,37 @@ export const CommentsSection = ({ id }: CommentsSectionProps) => {
     author.trim().length > COMMENT_AUTHOR_MAX_LENGTH
 
   return (
-    <section className="px-6 pb-10">
+    <section
+      className="px-6 pb-10"
+      aria-busy={isLoading || isSubmitting || pendingDeleteId !== null}>
+      {announcement && (
+        <p
+          key={announcement.id}
+          className="sr-only"
+          aria-live={announcement.politeness}
+          aria-atomic="true">
+          {announcement.message}
+        </p>
+      )}
       <div className="mb-5">
-        <h2 className="text-[1.625rem] font-bold text-gray-900">
+        <h2
+          ref={headingRef}
+          tabIndex={-1}
+          className="text-[1.625rem] font-bold text-gray-900 outline-none focus:outline-2 focus:outline-offset-2 focus:outline-gray-900">
           댓글 {comments.length}
         </h2>
-        <p className="mt-2 text-sm text-gray-500">
-          서로를 존중하는 댓글을 남겨주세요.
-        </p>
       </div>
       <CommentForm
         author={author}
         content={content}
-        errorMessage={formError}
+        authorErrorMessage={authorErrorMessage}
+        contentErrorMessage={contentErrorMessage}
+        generalErrorMessage={generalErrorMessage}
         isEditing={editingCommentId !== null}
         isSubmitDisabled={isSubmitDisabled}
         isSubmitting={isSubmitting}
+        focusTarget={focusTarget}
+        focusRequestToken={focusRequestToken}
         onAuthorChange={setAuthor}
         onContentChange={setContent}
         onCancelEdit={resetForm}
@@ -288,7 +381,7 @@ export const CommentsSection = ({ id }: CommentsSectionProps) => {
             <p>{loadError}</p>
             <button
               type="button"
-              className="mt-3 font-semibold underline underline-offset-4"
+              className="mt-3 font-semibold underline underline-offset-4 outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-900"
               onClick={() => setReloadToken((prevToken) => prevToken + 1)}>
               다시 시도
             </button>
@@ -301,11 +394,12 @@ export const CommentsSection = ({ id }: CommentsSectionProps) => {
           <p className="py-6 text-sm text-gray-400">첫 댓글을 남겨보세요.</p>
         )}
         {comments.length > 0 && (
-          <ul className="divide-y divide-gray-200">
+          <ul className="divide-y divide-gray-200" aria-label="댓글 목록">
             {comments.map((comment) => (
               <CommentItem
                 key={comment.id}
                 comment={comment}
+                elementId={`comment-item-${comment.id}`}
                 isOwned={ownedCommentIds.includes(comment.id)}
                 isActionDisabled={isSubmitting || pendingDeleteId !== null}
                 isDeleting={pendingDeleteId === comment.id}

--- a/src/domains/blog/[uid]/index.ts
+++ b/src/domains/blog/[uid]/index.ts
@@ -1,3 +1,5 @@
+export * from "./comment-types"
+export * from "./comments-section"
 export * from "./guiderun-link"
 export * from "./like-button"
 export * from "./team-profile"

--- a/src/utils/spreadsheet.ts
+++ b/src/utils/spreadsheet.ts
@@ -1,5 +1,8 @@
 import { JWT } from "google-auth-library"
-import { GoogleSpreadsheet } from "google-spreadsheet"
+import {
+  GoogleSpreadsheet,
+  GoogleSpreadsheetWorksheet,
+} from "google-spreadsheet"
 
 const serviceAccountAuth = new JWT({
   email: process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL,
@@ -21,4 +24,38 @@ export async function getLoadedSheet(): Promise<GoogleSpreadsheet> {
   }
 
   return doc
+}
+
+export async function getOrCreateSheet(
+  title: string,
+  headerValues: string[]
+): Promise<GoogleSpreadsheetWorksheet> {
+  const loadedDoc = await getLoadedSheet()
+  const existingSheet = loadedDoc.sheetsByTitle[title]
+
+  if (!existingSheet) {
+    return loadedDoc.addSheet({ title, headerValues })
+  }
+
+  try {
+    await existingSheet.loadHeaderRow()
+  } catch {
+    await existingSheet.setHeaderRow(headerValues)
+    return existingSheet
+  }
+
+  const currentHeaders = existingSheet.headerValues.map((value) => value.trim())
+  const expectedHeaders = headerValues.map((value) => value.trim())
+
+  const isSameHeader =
+    currentHeaders.length === expectedHeaders.length &&
+    currentHeaders.every((value, index) => value === expectedHeaders[index])
+
+  if (!isSameHeader) {
+    throw new Error(
+      `Sheet '${title}' header mismatch. Expected: ${expectedHeaders.join(", ")}`
+    )
+  }
+
+  return existingSheet
 }


### PR DESCRIPTION
## 변경 배경
- 블로그 상세 페이지에 좋아요 외에 댓글 기능이 없어 사용자 반응을 남기기 어려웠습니다.
- 별도 서버/DB 없이 기존 좋아요와 유사하게 Google Sheets 기반으로 댓글을 운영할 수 있도록 구성했습니다.
- 시각장애 사용자를 고려해 댓글 UI 접근성과 응답성을 함께 보완했습니다.

## 주요 변경 사항
- 블로그 상세 페이지에 댓글 섹션 추가
- Google Sheets 기반 댓글 조회/작성/수정/삭제 API 추가
- LocalStorage 기반 내 댓글 수정/삭제 처리 추가
- 작성자 기본값을 `익명의 러너`로 설정하고 작성자 수정 가능하게 구성
- 댓글 입력창에 500자 제한 및 실시간 글자 수 표시 추가
- 포커스 이동, 라이브 리전, 필드 설명 연결 등 접근성 보완
- 댓글 작성/수정/삭제에 낙관적 업데이트 적용으로 체감 응답 속도 개선

## 검증
- `npm run build`

## 참고
- 댓글 데이터는 Google Sheets의 `comments` 시트를 사용합니다.
- 현재 구조상 LocalStorage 기반으로 같은 브라우저에서만 수정/삭제 UI가 노출됩니다.